### PR TITLE
Memory leak correction

### DIFF
--- a/src/mesh/mesh.c
+++ b/src/mesh/mesh.c
@@ -449,7 +449,11 @@ int mesh_free(mesh_t *mesh) {
         free(mesh->cell[i].index);
       }
       if (mesh->cell[i].neighbor != NULL) {
-        free(mesh->cell[i].neighbor);
+	for(int k = 0; k<mesh->cell[i].n_neighbors; k++) {
+	  if(mesh->cell[i].neighbor[k].face_coord != NULL)
+	    free(mesh->cell[i].neighbor[k].face_coord);
+	}
+	free(mesh->cell[i].neighbor);
       }
       if (mesh->cell[i].ifaces != NULL) {
         for (j = 0; j < mesh->cell[i].element->type->faces; j++) {


### PR DESCRIPTION
Hi Germán, hope you and the family are fine.
A small correction I did when running milonga. I tested the correction under it, but could not extensively run in wasora using the example files provided which load meshes. Anyway, valgrind told me the correction works.
 
Before:

==22274== LEAK SUMMARY:
==22274==    definitely lost: 38,753,312 bytes in 1,614,722 blocks
==22274==    indirectly lost: 0 bytes in 0 blocks
==22274==      possibly lost: 24 bytes in 1 blocks
==22274==    still reachable: 4,986,402 bytes in 2,624 blocks
==22274==         suppressed: 0 bytes in 0 blocks
==22274== Reachable blocks (those to which a pointer was found) are not shown.
==22274== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==22274== 
==22274== For lists of detected and suppressed errors, rerun with: -s
==22274== ERROR SUMMARY: 5 errors from 5 contexts (suppressed: 0 from 0)

After:

==24506== LEAK SUMMARY:
==24506==    definitely lost: 56 bytes in 3 blocks
==24506==    indirectly lost: 0 bytes in 0 blocks
==24506==      possibly lost: 0 bytes in 0 blocks
==24506==    still reachable: 4,986,402 bytes in 2,624 blocks
==24506==         suppressed: 0 bytes in 0 blocks
==24506== Reachable blocks (those to which a pointer was found) are not shown.
==24506== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==24506== 
==24506== For lists of detected and suppressed errors, rerun with: -s
==24506== ERROR SUMMARY: 3 errors from 3 contexts (suppressed: 0 from 0)

